### PR TITLE
Expand listing search and assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,6 +293,7 @@
           <option value="education">Education</option>
           <option value="healthcare">Healthcare</option>
           <option value="infrastructure">Infrastructure</option>
+          <option value="economy">Economy</option>
           <option value="government">Government Services</option>
         </select>
         <button type="submit">Search</button>

--- a/listings.html
+++ b/listings.html
@@ -61,6 +61,7 @@
           <option value="education">Education</option>
           <option value="healthcare">Healthcare</option>
           <option value="infrastructure">Infrastructure</option>
+          <option value="economy">Economy</option>
           <option value="government">Government Services</option>
         </select>
         <button type="submit">Search</button>
@@ -257,6 +258,63 @@
               <span><i class="fas fa-users"></i> 350,000+ Rural Residents</span>
             </div>
             <a href="usps-listing.html" class="view-listing">View Details</a>
+          </div>
+        </div>
+
+        <!-- VA Healthcare Listing -->
+        <div class="listing-item" data-category="healthcare">
+          <div class="listing-image">
+            <img src="https://images.unsplash.com/photo-1586773860418-d37222d8fce3?ixlib=rb-4.0.3&w=1200" alt="VA Burn Pit Facility">
+            <div class="listing-badge healthcare">Healthcare</div>
+          </div>
+          <div class="listing-content">
+            <h3>VA Burn-Pit Treatment Center</h3>
+            <p class="listing-price">Price on Request <span class="negstatus">VETS NOT INCLUDED</span></p>
+            <p class="listing-description">Privatize veteran healthcare for maximum profit! Toxic exposure coverage sold separately.</p>
+            <div class="listing-features">
+              <span><i class="fas fa-procedures"></i> 300k MN Veterans</span>
+              <span><i class="fas fa-smoking"></i> Burn Pit Illnesses</span>
+              <span><i class="fas fa-dollar-sign"></i> Guaranteed Payments</span>
+            </div>
+            <a href="va-burnpit-listing.html" class="view-listing">View Details</a>
+          </div>
+        </div>
+
+        <!-- Democracy Listing -->
+        <div class="listing-item" data-category="government">
+          <div class="listing-image">
+            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Capitol_Building_Full_View.jpg/2560px-Capitol_Building_Full_View.jpg" alt="Democracy For Sale">
+            <div class="listing-badge government">Government</div>
+          </div>
+          <div class="listing-content">
+            <h3>Democracy - Premium Political Control</h3>
+            <p class="listing-price">Priceless <span class="negstatus">SOLD TO DONORS</span></p>
+            <p class="listing-description">Why let citizens decide? Buy the whole system and write your own laws!</p>
+            <div class="listing-features">
+              <span><i class="fas fa-vote-yea"></i> Voting Rights Optional</span>
+              <span><i class="fas fa-gavel"></i> Total Influence</span>
+              <span><i class="fas fa-user-tie"></i> Lobbyist Approved</span>
+            </div>
+            <a href="democracy.html" class="view-listing">View Details</a>
+          </div>
+        </div>
+
+        <!-- SNAP Food Assistance Listing -->
+        <div class="listing-item" data-category="government">
+          <div class="listing-image">
+            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Empty_meat_shelves_Colorado.jpg/1024px-Empty_meat_shelves_Colorado.jpg" alt="SNAP Program">
+            <div class="listing-badge government">Government</div>
+          </div>
+          <div class="listing-content">
+            <h3>SNAP Food Assistance Program</h3>
+            <p class="listing-price">30% OFF <span class="negstatus">CLEARANCE</span></p>
+            <p class="listing-description">Slash food aid for 453,900 Minnesotans and turn hunger into opportunity.</p>
+            <div class="listing-features">
+              <span><i class="fas fa-utensils"></i> 453k Recipients</span>
+              <span><i class="fas fa-cut"></i> 30% Benefit Cut</span>
+              <span><i class="fas fa-hand-holding-usd"></i> Tax Breaks Funded</span>
+            </div>
+            <a href="snap-listing.html" class="view-listing">View Details</a>
           </div>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -476,11 +476,20 @@ function setupSearchFunctionality() {
   const searchInput = document.querySelector('.search-form input[name="q"]');
   const categorySelect = document.querySelector('.search-form select[name="category"]');
   const listingItems = document.querySelectorAll('.listing-item');
+  const listingsGrid = document.querySelector('.listings-grid');
   
   // Only run if we're on a page with the search form and listings
   if (!searchForm || !listingItems.length) {
     return;
   }
+
+  // Sort listings alphabetically by title
+  const sortedItems = Array.from(listingItems).sort((a, b) => {
+    const titleA = a.querySelector('h3').textContent.trim();
+    const titleB = b.querySelector('h3').textContent.trim();
+    return titleA.localeCompare(titleB);
+  });
+  sortedItems.forEach(item => listingsGrid.appendChild(item));
   
   // Prevent the form from submitting and going to the error page
   searchForm.addEventListener('submit', function(event) {
@@ -503,13 +512,14 @@ function setupSearchFunctionality() {
       const itemCategory = item.getAttribute('data-category');
       
       const matchesSearch = !searchTerm || itemText.includes(searchTerm);
-      const matchesCategory = selectedCategory === 'all' || 
+      const matchesCategory = selectedCategory === 'all' ||
                              (selectedCategory === 'public' && (itemCategory === 'healthcare' || itemCategory === 'infrastructure')) ||
                              (selectedCategory === 'parks' && itemCategory === 'environment') ||
                              (selectedCategory === 'education' && itemText.includes('school')) ||
                              (selectedCategory === 'healthcare' && itemCategory === 'healthcare') ||
                              (selectedCategory === 'infrastructure' && itemCategory === 'infrastructure') ||
-                             (selectedCategory === 'government' && itemText.includes('government'));
+                             (selectedCategory === 'government' && itemCategory === 'government') ||
+                             (selectedCategory === 'economy' && itemCategory === 'economy');
       
       if (matchesSearch && matchesCategory) {
         item.style.display = 'flex';
@@ -557,6 +567,19 @@ function setupSearchFunctionality() {
     const event = new Event('submit');
     searchForm.dispatchEvent(event);
   });
+
+  // Apply search parameters from URL on load
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('q')) {
+    searchInput.value = params.get('q');
+  }
+  if (params.has('category')) {
+    categorySelect.value = params.get('category');
+  }
+  if (params.has('q') || params.has('category')) {
+    const event = new Event('submit');
+    searchForm.dispatchEvent(event);
+  }
 }
 
 // Add this to the event listeners at the top of the file


### PR DESCRIPTION
## Summary
- include economy category in search forms
- list VA healthcare, democracy, and food assistance assets on listings page
- sort listings alphabetically and read search params
- extend filtering to government and economy listings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860bd4dab18832980f94ecc99a598a2